### PR TITLE
feature: filter entries before writes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,6 @@ type Config struct {
 var C Config
 
 func init() {
-	// Load TOML config
 
 	var intermediate_config struct {
 		Repos         []string

--- a/org/org.go
+++ b/org/org.go
@@ -17,6 +17,7 @@ type OrgTODO interface {
 	StartLine() int
 	LinesCount() int
 	Repo() string
+	Identifier() string
 }
 
 func CleanHeader(line string) string {

--- a/org/org_parser.go
+++ b/org/org_parser.go
@@ -407,6 +407,10 @@ func (oi OrgItem) CheckDone() bool {
 	return oi.GetStatus() == "DONE" || oi.GetStatus() == "CANCELLED"
 }
 
+func (oi OrgItem) Identifier() string {
+	return oi.details[0] + oi.details[1]
+}
+
 func findOrgTags(line string) []string {
 	splits := strings.Split(line, ":")
 	if len(splits) < 2 {

--- a/workflows/logic.go
+++ b/workflows/logic.go
@@ -87,6 +87,10 @@ func (prb PRToOrgBridge) Title() string {
 	return *prb.PR.Title
 }
 
+func (prb PRToOrgBridge) Identifier() string {
+	return prb.Repo() + prb.ID()
+}
+
 func (prb PRToOrgBridge) ItemTitle(indent_level int, release_check_command string) string {
 
 	line := fmt.Sprintf("%s %s %s\t\t:%s:", strings.Repeat("*", indent_level), prb.GetStatus(), prb.Title(), *prb.PR.Head.Repo.Name)

--- a/workflows/manager_test.go
+++ b/workflows/manager_test.go
@@ -1,0 +1,69 @@
+package workflows
+
+import (
+	"gtdbot/org"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestDeduplicateChanges(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	tests := []struct {
+		name     string
+		changes  []SerializedFileChange
+		expected int
+	}{
+		{
+			name: "Single Add",
+			changes: []SerializedFileChange{
+				{FileChange: &FileChanges{ChangeType: "Addition", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+			},
+			expected: 1,
+		},
+		{
+			name: "Add and Update",
+			changes: []SerializedFileChange{
+				{FileChange: &FileChanges{ChangeType: "Addition", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Update", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+			},
+			expected: 1,
+		},
+		{
+			name: "Add, Update and Delete",
+			changes: []SerializedFileChange{
+				{FileChange: &FileChanges{ChangeType: "Addition", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Update", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Delete", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+			},
+			expected: 1,
+		},
+		{
+			name: "Only Deletes",
+			changes: []SerializedFileChange{
+				{FileChange: &FileChanges{ChangeType: "Delete", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Delete", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+			},
+			expected: 1,
+		},
+		{
+			name: "Multiple Items",
+			changes: []SerializedFileChange{
+				{FileChange: &FileChanges{ChangeType: "Addition", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Update", Item: org.NewOrgItem("Test Item 1", []string{"1", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Addition", Item: org.NewOrgItem("Test Item 2", []string{"2", "test-repo"}, "TODO", []string{}, 0, 1)}},
+				{FileChange: &FileChanges{ChangeType: "Delete", Item: org.NewOrgItem("Test Item 2", []string{"2", "test-repo"}, "TODO", []string{}, 0, 1)}},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deduplicateChanges(logger, tt.changes)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d changes, got %d", tt.expected, len(result))
+			}
+		})
+	}
+}


### PR DESCRIPTION
if multiple services are writing to the same file, it's easy to have duplicates or have an add and a delete. 

this has a reconciliation process before doing the actual writes.